### PR TITLE
Add logs for job enqueue & fix future last_run test case failure

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
+config :logger, level: :warn
+
 config :exq_scheduler,
   missed_jobs_window: 60 * 60 * 1000,
   time_zone: "Asia/Kolkata"

--- a/lib/exq_scheduler/scheduler/server.ex
+++ b/lib/exq_scheduler/scheduler/server.ex
@@ -105,7 +105,7 @@ defmodule ExqScheduler.Scheduler.Server do
   defp handle_tick(state, ref_time) do
     window_duration = state.server_opts.missed_jobs_window
 
-    Storage.filter_active_jobs(
+    Storage.filter_active_schedules(
       state.storage_opts,
       state.schedules,
       get_range(window_duration, ref_time),

--- a/lib/exq_scheduler/storage.ex
+++ b/lib/exq_scheduler/storage.ex
@@ -181,7 +181,7 @@ defmodule ExqScheduler.Storage do
     Redis.hkeys(storage_opts, schedules_key)
   end
 
-  def filter_active_jobs(storage_opts, schedules, time_range, ref_time) do
+  def filter_active_schedules(storage_opts, schedules, time_range, ref_time) do
     Enum.filter(schedules, &Storage.is_schedule_enabled?(storage_opts, &1))
     |> Enum.map(&{&1, Schedule.get_jobs(storage_opts, &1, time_range, ref_time)})
   end

--- a/test/exq_scheduler_time_test.exs
+++ b/test/exq_scheduler_time_test.exs
@@ -76,7 +76,7 @@ defmodule ExqSchedulerTimeTest do
 
     storage_opts = Storage.build_opts(config)
     schedules = Storage.load_schedules_config(config)
-    start_time = Timex.add(Time.now(), Duration.from_hours(1))
+    start_time = Timex.add(Time.now(), Duration.from_hours(10))
 
     Storage.persist_schedule_times(schedules, storage_opts, start_time)
 


### PR DESCRIPTION
1. Logs are added for job enqueue, changed test log level to 'warn'
2. Future last_run test case failure fixed by setting the future date to too far in future