### PR TITLE
support redis config as list

### DIFF
--- a/lib/exq_scheduler.ex
+++ b/lib/exq_scheduler.ex
@@ -61,6 +61,10 @@ defmodule ExqScheduler do
       is_map(spec) ->
         spec
 
+      is_list(spec) ->
+        {module, args} = hd(spec)
+        module.child_spec(args)
+
       true ->
         raise ExqScheduler.ConfigurationError,
           message:

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -45,4 +45,14 @@ defmodule ConfigTest do
     {:ok, _} = start_supervised({ExqScheduler, env})
     assert Supervisor.which_children(name) == []
   end
+
+  test "if redix config is a list" do
+    redis_config = Application.get_env(:exq_scheduler, :redis)
+    child_spec = redis_config[:child_spec]
+    wrapped_redis_config = Keyword.put(redis_config, :child_spec, [child_spec])
+    Application.put_env(:exq_scheduler, :redis, wrapped_redis_config)
+
+    config = configure_env(env(), 1000 * 60 * 120, [])
+    assert {:ok, pid} = ExqScheduler.start_link(config)
+  end
 end


### PR DESCRIPTION
Greetings, I have a config provider (aws_ssm_provider) that merges each value one at a time, but into a list. This change would allow me to continue using my config provider and start using exq-scheduler. Please let me know if you'd like any modifications.