### PR TITLE
Test on elixir 1.10 and fix deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,17 @@ language: elixir
 env:
   TOXIPROXY_VERSION="2.1.3"
 
-elixir:
-  - 1.5
-  - 1.6
-
-otp_release:
-  - 19.3
-  - 20.3
+jobs:
+  - elixir: 1.5
+    otp_release: 19.3
+  - elixir: 1.6
+    otp_release: 20.3
+  - elixir: 1.9.4
+    otp_release: 20.3.8
+  - elixir: 1.10.4
+    otp_release: 21.3.8
+  - elixir: 1.10.4
+    otp_release: 23.0.3
 
 services:
   - redis-server
@@ -27,6 +31,7 @@ before_script:
   - sleep 4
   - toxiproxy-cli create redis -l localhost:26379 -u localhost:6379
   - sleep 1
+  - mix compile --warnings-as-errors
 
 script:
   - "! mix help format > /dev/null || mix format --check-formatted"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ before_script:
   - sleep 4
   - toxiproxy-cli create redis -l localhost:26379 -u localhost:6379
   - sleep 1
-  - mix compile --warnings-as-errors
 
 script:
+  - mix compile --warnings-as-errors
   - "! mix help format > /dev/null || mix format --check-formatted"
   - mix test --include integration --trace

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -369,7 +369,7 @@ defmodule ScheduleTest do
       |> hd
 
     now = Schedule.utc_to_localtime(time, @timezone)
-    assert Timex.compare(recent_schedule, now, :seconds) != 1
+    assert Timex.compare(recent_schedule, now, :second) != 1
   end
 
   @sample_date Timex.parse!("2018-12-01T00:00:00Z", "{ISO:Extended:Z}")

--- a/test/scheduler_serdes_test.exs
+++ b/test/scheduler_serdes_test.exs
@@ -5,18 +5,18 @@ defmodule SchedulerSerdesTest do
   require Logger
 
   setup context do
-    sidekiq_path = System.cwd() |> Path.join("./sidekiq")
+    sidekiq_path = Path.join(__DIR__, "../sidekiq") |> Path.expand()
 
     sidekiq_task =
       Task.async(fn ->
-        System.cmd("#{sidekiq_path}/setup_sidekiq", [], cd: sidekiq_path)
+        {_, 0} = System.cmd(Path.join(sidekiq_path, "setup_sidekiq"), [], cd: sidekiq_path)
       end)
 
     Logger.info("Wait for 5 seconds for Sidekiq to initialize.")
     :timer.sleep(5000)
 
     on_exit(context, fn ->
-      System.cmd("#{sidekiq_path}/stop_sidekiq", [], cd: sidekiq_path)
+      System.cmd(Path.join(sidekiq_path, "stop_sidekiq"), [], cd: sidekiq_path)
       assert_down(sidekiq_task.pid)
     end)
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -154,7 +154,7 @@ defmodule TestUtils do
     spec = ExqScheduler.redix_spec(env)
 
     [opts | rest] = get_opts(spec)
-    opts = Keyword.replace(opts, :port, port)
+    opts = Keyword.put(opts, :port, port)
     spec = set_opts(spec, [opts | rest])
 
     put_in(env[:redis][:child_spec], spec)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -189,7 +189,7 @@ defmodule TestUtils do
   def scheduled_at_local(job, timezone) do
     scheduled_at(job)
     |> trunc
-    |> Timex.from_unix()
+    |> Timex.from_unix(:second)
     |> Schedule.utc_to_localtime(timezone)
   end
 


### PR DESCRIPTION
This sets up travis to test on elixir 1.9.4 and 10.10.4 and fixes the deprecation warnings in the tests when running on these versions of Elixir.