### PR TITLE
Fix some deprecations, broken applications list, add support for alternative json serializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ It uses `"#{exq_namespace}:sidekiq-scheduler"` for storing scheduler internal me
 ```elixir
 config :exq_scheduler, :storage,
   exq_namespace: "exq" # exq redis namespace
+  json_serializer: Jason # or Poison, which is the default if not provided
 ```
 ### Redis Client
 

--- a/lib/exq_scheduler/serializer.ex
+++ b/lib/exq_scheduler/serializer.ex
@@ -1,0 +1,11 @@
+defmodule ExqScheduler.Serializer do
+  @serializer Application.fetch_env!(:exq_scheduler, :storage)[:json_serializer] || Poison
+
+  def encode!(object, opts \\ []) do
+    @serializer.encode!(object, opts)
+  end
+
+  def decode!(data, opts \\ []) do
+    @serializer.decode!(data, opts)
+  end
+end

--- a/lib/exq_scheduler/storage.ex
+++ b/lib/exq_scheduler/storage.ex
@@ -7,6 +7,8 @@ defmodule ExqScheduler.Storage do
   @schedule_first_runs_key "first_runs"
   @schedule_last_runs_key "last_runs"
 
+  alias ExqScheduler.Serializer
+
   defmodule Opts do
     @moduledoc false
     @enforce_keys [:namespace, :exq_namespace, :name, :module]
@@ -34,7 +36,7 @@ defmodule ExqScheduler.Storage do
 
     schedule_state =
       %{enabled: schedule.schedule_opts.enabled}
-      |> Poison.encode!()
+      |> Serializer.encode!()
 
     Redis.hset(
       storage_opts,
@@ -55,7 +57,7 @@ defmodule ExqScheduler.Storage do
     Enum.each(schedules, fn schedule ->
       prev_time =
         Schedule.get_previous_schedule_date(schedule.cron, schedule.timezone, ref_time)
-        |> Poison.encode!()
+        |> Serializer.encode!()
 
       Redis.hset(
         storage_opts,
@@ -66,7 +68,7 @@ defmodule ExqScheduler.Storage do
 
       next_time =
         Schedule.get_next_schedule_date(schedule.cron, schedule.timezone, ref_time)
-        |> Poison.encode!()
+        |> Serializer.encode!()
 
       Redis.hset(
         storage_opts,
@@ -75,7 +77,7 @@ defmodule ExqScheduler.Storage do
         next_time
       )
 
-      now = ref_time |> Timex.to_naive_datetime() |> Poison.encode!()
+      now = ref_time |> Timex.to_naive_datetime() |> Serializer.encode!()
 
       schedule_first_run = get_schedule_first_run_time(storage_opts, schedule)
 

--- a/lib/exq_scheduler/storage/redis.ex
+++ b/lib/exq_scheduler/storage/redis.ex
@@ -1,6 +1,8 @@
 defmodule ExqScheduler.Storage.Redis do
   @moduledoc false
 
+  alias ExqScheduler.Serializer
+
   def hkeys(storage, key) do
     storage.module.command!(storage.name, ["HKEYS", key])
   end
@@ -53,7 +55,7 @@ defmodule ExqScheduler.Storage.Redis do
 
   defp decode(result) do
     if result != nil do
-      result |> Poison.decode!()
+      result |> Serializer.decode!()
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,8 @@ defmodule ExqScheduler.Mixfile do
       dialyzer: [
         plt_add_deps: :transitive,
         flags: [:unmatched_returns, :race_conditions, :error_handling, :underspecs]
-      ]
+      ],
+      xref: [exclude: [Jason]]
     ]
   end
 
@@ -31,7 +32,7 @@ defmodule ExqScheduler.Mixfile do
       {:timex, ">= 3.1.0 and < 3.4.0"},
       {:redix, "~> 0.7"},
       {:redix_sentinel, "~> 0.6.0", only: :test},
-      {:poison, "~> 3.1"},
+      {:poison, "~> 3.1", optional: true},
       {:crontab, "~> 1.1"},
       {:elixir_uuid, "~> 1.2"},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},

--- a/test/schedule_parser_test.exs
+++ b/test/schedule_parser_test.exs
@@ -1,6 +1,7 @@
 defmodule ScheduleParserTest do
   use ExUnit.Case, async: false
   alias ExqScheduler.Schedule.Parser
+  alias ExqScheduler.Serializer
 
   test "it correctly parses a cron-based schedule containing bitstrings" do
     schedule = %{
@@ -14,7 +15,7 @@ defmodule ScheduleParserTest do
              {
                "",
                "* * * * * * Asia/Kolkata",
-               Poison.encode!(%{
+               Serializer.encode!(%{
                  :class => "SidekiqWorker",
                  :queue => "high",
                  :args => ["/tmp/poop"]
@@ -36,7 +37,7 @@ defmodule ScheduleParserTest do
              {
                "this is a test",
                "* * * * * * Asia/Kolkata",
-               Poison.encode!(%{
+               Serializer.encode!(%{
                  :class => "SidekiqWorker",
                  :queue => "high",
                  :args => ["/tmp/poop"]
@@ -57,7 +58,7 @@ defmodule ScheduleParserTest do
              {
                "",
                "* * * * * * Asia/Kolkata",
-               Poison.encode!(%{
+               Serializer.encode!(%{
                  :class => "SidekiqWorker",
                  :queue => "high",
                  :args => ["/tmp/poop"]
@@ -78,7 +79,7 @@ defmodule ScheduleParserTest do
              {
                "",
                "1 * * * * * Asia/Kolkata",
-               Poison.encode!(%{
+               Serializer.encode!(%{
                  :class => "SidekiqWorker",
                  :queue => "high",
                  :args => ["/tmp/poop"]


### PR DESCRIPTION
As indicated in the title, this combines a few fixes and one new configuration option for which JSON serializer to use.

1. The `applications` list in `mix.exs` was not only unnecessary to explicitly provide, but it was missing `:poison` and so broke releases that do not otherwise depend on `:poison`
2. The use of `Supervisor.Spec.worker/2` is deprecated, so I've updated those usages to the child spec format
3. Finally, I've added a new option `config :exq_scheduler, :storage, json_serializer: <module>` that allows users to provide their own JSON serializer, e.g. `Jason` instead of `Poison`. I've also made `Poison` an optional dependency so that it is not needed at all when using other serializers.

Let me know if you have any changes you'd like to make to this! Thanks!